### PR TITLE
jenkins terraform pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Terraform state files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# .terraform directory
+.terraform/
+
+# Terraform variable files
+*.tfvars
+*.tfvars.json
+
+# Sensitive override files
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# CLI configuration files
+.terraformrc
+terraform.rc
+
+# IDE/editor files (optional but helpful)
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+Thumbs.db

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.0.0"
+  constraints = "6.0.0"
+  hashes = [
+    "h1:4l7id1i0H64icn/fDJq7gIe9Iui55JYyPP2ivzWbNFI=",
+    "zh:16b1bb786719b7ebcddba3ab751b976ebf4006f7144afeebcb83f0c5f41f8eb9",
+    "zh:1fbc08b817b9eaf45a2b72ccba59f4ea19e7fcf017be29f5a9552b623eccc5bc",
+    "zh:304f58f3333dbe846cfbdfc2227e6ed77041ceea33b6183972f3f8ab51bd065f",
+    "zh:4cd447b5c24f14553bd6e1a0e4fea3c7d7b218cbb2316a3d93f1c5cb562c181b",
+    "zh:589472b56be8277558616075fc5480fcd812ba6dc70e8979375fc6d8750f83ef",
+    "zh:5d78484ba43c26f1ef6067c4150550b06fd39c5d4bfb790f92c4a6f7d9d0201b",
+    "zh:5f470ce664bffb22ace736643d2abe7ad45858022b652143bcd02d71d38d4e42",
+    "zh:7a9cbb947aaab8c885096bce5da22838ca482196cf7d04ffb8bdf7fd28003e47",
+    "zh:854df3e4c50675e727705a0eaa4f8d42ccd7df6a5efa2456f0205a9901ace019",
+    "zh:87162c0f47b1260f5969679dccb246cb528f27f01229d02fd30a8e2f9869ba2c",
+    "zh:9a145404d506b52078cd7060e6cbb83f8fc7953f3f63a5e7137d41f69d6317a3",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a4eab2649f5afe06cc406ce2aaf9fd44dcf311123f48d344c255e93454c08921",
+    "zh:bea09141c6186a3e133413ae3a2e3d1aaf4f43466a6a468827287527edf21710",
+    "zh:d7ea2a35ff55ddfe639ab3b04331556b772a8698eca01f5d74151615d9f336db",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,16 @@
 //defining data block
 
-data "aws_ami" "amazon-linux-3" { # we are reading aws_ami reource and naming it as amazon-linux-3
+data "aws_ami" "amazon_linux_2023" {
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["al2023-ami-2023.*"]
+    values = ["al2023-ami-*-x86_64"]
   }
 
   filter {
-    name   = "owner-alias"
-    values = ["amazon"]
+    name   = "architecture"
+    values = ["x86_64"]
   }
 
   filter {
@@ -18,16 +18,12 @@ data "aws_ami" "amazon-linux-3" { # we are reading aws_ami reource and naming it
     values = ["hvm"]
   }
 
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
+  owners = ["137112412989"] # Amazon official
 }
 
 
-
 resource "aws_instance" "dev_instance" {
-  ami           = data.aws_ami.amazon-linux-3.id # <block name>.<resource name>.<common name>.id
+  ami           = data.aws_ami.amazon_linux_2023.id # <block name>.<resource name>.<common name>.id
   instance_type = var.instance_size
   count         = var.instance_count
   key_name      = var.instance_key
@@ -36,4 +32,8 @@ resource "aws_instance" "dev_instance" {
     Name        = "My Dev Server"
     Environment = "Dev"
   }
+}
+
+resource "aws_vpc" "aws_vpc_example" {
+  cidr_block = "10.0.0.0/16"
 }

--- a/provider.tf
+++ b/provider.tf
@@ -1,12 +1,12 @@
 provider "aws" {
-    region = "ap-south-1"
+  region = "ap-south-1"
 }
 
 terraform {
-    required_providers {
-        aws = {
-            souce = "hashicorp/aws"
-            version = "6.0.0"
-        }
+  required_providers {
+    aws = {
+      source   = "hashicorp/aws"
+      version = "6.0.0"
     }
+  }
 }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,3 +1,4 @@
 instance_size  = "t2.micro"
 instance_count = 1
 instance_key   = "JenkinsMaster-May25" //picked from AWS key pairs
+cidr_block = "10.0.0.0/16"

--- a/variable.tf
+++ b/variable.tf
@@ -9,3 +9,7 @@ variable "instance_count" {
 variable "instance_key" {
   type = string
 }
+
+variable "cidr_block" {
+  type = string
+}


### PR DESCRIPTION
$ terraform plan
data.aws_ami.amazon_linux_2023: Reading...
data.aws_ami.amazon_linux_2023: Read complete after 0s [id=ami-044c50da7a3450dd6]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the   
following symbols:
  + create

Terraform will perform the following actions:

  # aws_instance.dev_instance[0] will be created
  + resource "aws_instance" "dev_instance" {
      + ami                                  = "ami-044c50da7a3450dd6"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = (known after apply)
      + availability_zone                    = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + enable_primary_ipv6                  = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "JenkinsMaster-May25"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + region                               = "ap-south-1"
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = (known after apply)
      + tags                                 = {
          + "Environment" = "Dev"
          + "Name"        = "My Dev Server"
        }
      + tags_all                             = {
          + "Environment" = "Dev"
          + "Name"        = "My Dev Server"
        }
      + tenancy                              = (known after apply)
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = (known after apply)

      + capacity_reservation_specification (known after apply)

      + cpu_options (known after apply)

      + ebs_block_device (known after apply)

      + enclave_options (known after apply)

      + ephemeral_block_device (known after apply)

      + instance_market_options (known after apply)

      + maintenance_options (known after apply)

      + metadata_options (known after apply)

      + network_interface (known after apply)

      + private_dns_name_options (known after apply)

      + root_block_device (known after apply)
    }

  # aws_vpc.aws_vpc_example will be created
  + resource "aws_vpc" "aws_vpc_example" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + region                               = "ap-south-1"
      + tags_all                             = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.